### PR TITLE
link to fixed ellie in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 It uses a syntax similar to `Json.Decode.Pipeline`.
 
 You can
-play around with `elm-cli-options-parser` in a [live terminal simulation in Ellie here](https://rebrand.ly/elm-cli)!
+play around with `elm-cli-options-parser` in a [live terminal simulation in Ellie here](https://ellie-app.com/83xwGryJX9ya1)!
 
 ## Example
 


### PR DESCRIPTION
The ellie linked in the readme does not compile. This commit changes it to 
link to an ellie that does.

The link is currently points to https://rebrand.ly/elm-cli, I don't know if link could keep pointing there and the forwarding changed to the new ellie (which is https://ellie-app.com/83xwGryJX9ya1) instead.