### PR TITLE
Allow accessing cliOptions from subscriptions

### DIFF
--- a/examples/src/Curl.elm
+++ b/examples/src/Curl.elm
@@ -61,5 +61,5 @@ main =
         , init = init
         , config = program
         , update = update
-        , subscriptions = \_ -> Sub.none
+        , subscriptions = \_ _ -> Sub.none
         }

--- a/examples/src/Grep.elm
+++ b/examples/src/Grep.elm
@@ -119,8 +119,8 @@ update cliOptions msg model =
                         ( model, Cmd.none )
 
 
-subscriptions : a -> Sub Msg
-subscriptions model =
+subscriptions : CliOptions -> a -> Sub Msg
+subscriptions _ model =
     Sub.map OnStdin Stdin.subscriptions
 
 

--- a/src/Cli/Program.elm
+++ b/src/Cli/Program.elm
@@ -157,7 +157,7 @@ type alias StatefulOptions msg model cliOptions flags =
     , printAndExitSuccess : String -> Cmd msg
     , init : FlagsIncludingArgv flags -> cliOptions -> ( model, Cmd msg )
     , update : cliOptions -> msg -> model -> ( model, Cmd msg )
-    , subscriptions : model -> Sub msg
+    , subscriptions : cliOptions -> model -> Sub msg
     , config : Config cliOptions
     }
 
@@ -188,7 +188,7 @@ stateful options =
             \model ->
                 case model of
                     UserModel actualModel cliOptions ->
-                        options.subscriptions actualModel
+                        options.subscriptions cliOptions actualModel
 
                     ShowSystemMessage ->
                         Sub.none


### PR DESCRIPTION
This is, unfortunately, a breaking change. The reason to do it is that it would make the work on stateful scripts easier.