### PR TITLE
Collecting some breaking API changes for v4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.0.0]
+
+### Changed
+
+- `Option` type is now opaque. This shouldn't require any changes to your codebase but is a drop-in change.
+- `subscriptions` in `StatefulOptions` now receives `cliOptions` as first argument, allowing access to parsed CLI options from subscriptions.
+
+### Improved
+
+- Added and improved documentation throughout
+
 ## [3.2.0] - 2022-10-19
 
 ### Added

--- a/examples/src/Curl.elm
+++ b/examples/src/Curl.elm
@@ -61,5 +61,5 @@ main =
         , init = init
         , config = program
         , update = update
-        , subscriptions = \_ -> Sub.none
+        , subscriptions = \_ _ -> Sub.none
         }

--- a/examples/src/ElmTest.elm
+++ b/examples/src/ElmTest.elm
@@ -51,7 +51,7 @@ program =
                 |> with
                     (Option.optionalKeywordArg "report"
                         |> Option.withDefault "console"
-                        |> Option.oneOf Console
+                        |> Option.oneOf
                             [ ( "json", Json )
                             , ( "junit", Junit )
                             , ( "console", Console )

--- a/examples/src/Grep.elm
+++ b/examples/src/Grep.elm
@@ -119,8 +119,8 @@ update cliOptions msg model =
                         ( model, Cmd.none )
 
 
-subscriptions : a -> Sub Msg
-subscriptions model =
+subscriptions : CliOptions -> a -> Sub Msg
+subscriptions _ model =
     Sub.map OnStdin Stdin.subscriptions
 
 

--- a/review/suppressed/NoMissingTypeExpose.json
+++ b/review/suppressed/NoMissingTypeExpose.json
@@ -1,8 +1,0 @@
-{
-  "version": 1,
-  "automatically created by": "elm-review suppress",
-  "learn more": "elm-review suppress --help",
-  "suppressions": [
-    { "count": 1, "filePath": "src/Cli/Option.elm" }
-  ]
-}

--- a/review/suppressed/NoUnused.CustomTypeConstructorArgs.json
+++ b/review/suppressed/NoUnused.CustomTypeConstructorArgs.json
@@ -1,8 +1,0 @@
-{
-  "version": 1,
-  "automatically created by": "elm-review suppress",
-  "learn more": "elm-review suppress --help",
-  "suppressions": [
-    { "count": 1, "filePath": "src/Cli/Decode.elm" }
-  ]
-}

--- a/src/Cli/Option.elm
+++ b/src/Cli/Option.elm
@@ -6,7 +6,7 @@ module Cli.Option exposing
     , oneOf
     , validate, validateIfPresent, validateMap, validateMapIfPresent
     , map, mapFlag, withDefault
-    , Option(..), BeginningOption, OptionalPositionalArgOption, RestArgsOption
+    , Option, BeginningOption, OptionalPositionalArgOption, RestArgsOption
     )
 
 {-| Here is the terminology used for building up Command-Line parsers with this library.
@@ -106,6 +106,7 @@ with the following functions.
 -}
 
 import Cli.Decode
+import Cli.Option.Internal as Internal exposing (Option(..))
 import Cli.UsageSpec as UsageSpec exposing (UsageSpec)
 import Cli.Validate as Validate
 import List.Extra
@@ -115,8 +116,8 @@ import Tokenizer
 
 {-| The type returned by the builder functions below. Use with `OptionsParser.with`.
 -}
-type Option from to middleOrEnding
-    = Option (InnerOption from to)
+type alias Option from to middleOrEnding =
+    Internal.Option from to middleOrEnding
 
 
 {-| `BeginningOption`s can only be used with `OptionsParser.with`.
@@ -125,13 +126,13 @@ type Option from to middleOrEnding
 
 -}
 type BeginningOption
-    = BeginningOption
+    = BeginningOption Never
 
 
 {-| `RestArgsOption`s can only be used with `OptionsParser.withRestArgs`.
 -}
 type RestArgsOption
-    = RestArgsOption
+    = RestArgsOption Never
 
 
 {-| `BeginningOption`s can only be used with `OptionsParser.with`.
@@ -140,23 +141,7 @@ type RestArgsOption
 
 -}
 type OptionalPositionalArgOption
-    = OptionalPositionalArgOption
-
-
-type alias InnerOption from to =
-    { dataGrabber : DataGrabber from
-    , usageSpec : UsageSpec
-    , decoder : Cli.Decode.Decoder from to
-    }
-
-
-type alias DataGrabber decodesTo =
-    { usageSpecs : List UsageSpec
-    , operands : List String
-    , options : List Tokenizer.ParsedOption
-    , operandsSoFar : Int
-    }
-    -> Result Cli.Decode.ProcessingError decodesTo
+    = OptionalPositionalArgOption Never
 
 
 {-| Run a validation. (See an example in the Validation section above, or
@@ -320,7 +305,7 @@ flag flagName =
         (UsageSpec.flag flagName Optional)
 
 
-buildOption : DataGrabber a -> UsageSpec -> Option a a builderState
+buildOption : Internal.DataGrabber a -> UsageSpec -> Option a a builderState
 buildOption dataGrabber usageSpec =
     Option
         { dataGrabber = dataGrabber

--- a/src/Cli/Option.elm
+++ b/src/Cli/Option.elm
@@ -393,10 +393,6 @@ mapFlag { present, absent } option =
             )
 
 
-type alias MutuallyExclusiveValue union =
-    ( String, union )
-
-
 {-| Mutually exclusive option values.
 
     type ReportFormat
@@ -417,7 +413,7 @@ type alias MutuallyExclusiveValue union =
                     |> with
                         (Option.optionalKeywordArg "report"
                             |> Option.withDefault "console"
-                            |> Option.oneOf Console
+                            |> Option.oneOf
                                 [ "json" => Json
                                 , "junit" => Junit
                                 , "console" => Console
@@ -444,11 +440,9 @@ Value was:
 "xml"
 ```
 
-Note: the first argument is currently ignored. It will be removed in a future breaking API change.
-
 -}
-oneOf : value -> List (MutuallyExclusiveValue value) -> Option from String builderState -> Option from value builderState
-oneOf _ list (Option option) =
+oneOf : List ( String, value ) -> Option from String builderState -> Option from value builderState
+oneOf list (Option option) =
     validateMap
         (\argValue ->
             case

--- a/src/Cli/Option/Internal.elm
+++ b/src/Cli/Option/Internal.elm
@@ -1,0 +1,29 @@
+module Cli.Option.Internal exposing
+    ( Option(..)
+    , InnerOption
+    , DataGrabber
+    )
+
+import Cli.Decode
+import Cli.UsageSpec exposing (UsageSpec)
+import Tokenizer
+
+
+type Option from to middleOrEnding
+    = Option (InnerOption from to)
+
+
+type alias InnerOption from to =
+    { dataGrabber : DataGrabber from
+    , usageSpec : UsageSpec
+    , decoder : Cli.Decode.Decoder from to
+    }
+
+
+type alias DataGrabber decodesTo =
+    { usageSpecs : List UsageSpec
+    , operands : List String
+    , options : List Tokenizer.ParsedOption
+    , operandsSoFar : Int
+    }
+    -> Result Cli.Decode.ProcessingError decodesTo

--- a/src/Cli/OptionsParser.elm
+++ b/src/Cli/OptionsParser.elm
@@ -133,7 +133,8 @@ You shouldn't need to use these functions to build a command line utility.
 -}
 
 import Cli.Decode
-import Cli.Option exposing (Option(..))
+import Cli.Option
+import Cli.Option.Internal as Internal
 import Cli.OptionsParser.BuilderState as BuilderState
 import Cli.OptionsParser.MatchResult
 import Cli.UsageSpec as UsageSpec exposing (UsageSpec)
@@ -207,8 +208,8 @@ tryMatch argv ((OptionsParser { usageSpecs, subCommand }) as optionsParser) =
             case getDecoder parser actualFlagsAndOperands of
                 Err error ->
                     case error of
-                        Cli.Decode.MatchError _ ->
-                            Cli.OptionsParser.MatchResult.NoMatch []
+                        Cli.Decode.MatchError errorMessage ->
+                            Cli.OptionsParser.MatchResult.NoMatch [ errorMessage ]
 
                         Cli.Decode.UnrecoverableValidationError validationError ->
                             Cli.OptionsParser.MatchResult.Match (Err [ validationError ])
@@ -469,13 +470,13 @@ expectFlag flagName (OptionsParser ({ usageSpecs, decoder } as optionsParser)) =
 {-| For chaining on any `Cli.Option.Option` besides a `restArg` or an `optionalPositionalArg`.
 See the `Cli.Option` module.
 -}
-with : Option from to Cli.Option.BeginningOption -> OptionsParser (to -> cliOptions) BuilderState.AnyOptions -> OptionsParser cliOptions BuilderState.AnyOptions
+with : Cli.Option.Option from to Cli.Option.BeginningOption -> OptionsParser (to -> cliOptions) BuilderState.AnyOptions -> OptionsParser cliOptions BuilderState.AnyOptions
 with =
     withCommon
 
 
-withCommon : Option from to optionConstraint -> OptionsParser (to -> cliOptions) startOptionsParserBuilderState -> OptionsParser cliOptions endOptionsParserBuilderState
-withCommon (Option innerOption) ((OptionsParser { decoder, usageSpecs }) as fullOptionsParser) =
+withCommon : Cli.Option.Option from to optionConstraint -> OptionsParser (to -> cliOptions) startOptionsParserBuilderState -> OptionsParser cliOptions endOptionsParserBuilderState
+withCommon (Internal.Option innerOption) ((OptionsParser { decoder, usageSpecs }) as fullOptionsParser) =
     updateDecoder
         (\optionsAndOperands ->
             { options = optionsAndOperands.options
@@ -509,14 +510,14 @@ withCommon (Option innerOption) ((OptionsParser { decoder, usageSpecs }) as full
 
 {-| For chaining on `Cli.Option.optionalPositionalArg`s.
 -}
-withOptionalPositionalArg : Option from to Cli.Option.OptionalPositionalArgOption -> OptionsParser (to -> cliOptions) BuilderState.AnyOptions -> OptionsParser cliOptions BuilderState.NoBeginningOptions
+withOptionalPositionalArg : Cli.Option.Option from to Cli.Option.OptionalPositionalArgOption -> OptionsParser (to -> cliOptions) BuilderState.AnyOptions -> OptionsParser cliOptions BuilderState.NoBeginningOptions
 withOptionalPositionalArg =
     withCommon
 
 
 {-| For chaining on `Cli.Option.restArgs`.
 -}
-withRestArgs : Option from to Cli.Option.RestArgsOption -> OptionsParser (to -> cliOptions) startingBuilderState -> OptionsParser cliOptions BuilderState.NoMoreOptions
+withRestArgs : Cli.Option.Option from to Cli.Option.RestArgsOption -> OptionsParser (to -> cliOptions) startingBuilderState -> OptionsParser cliOptions BuilderState.NoMoreOptions
 withRestArgs =
     withCommon
 

--- a/src/Cli/Program.elm
+++ b/src/Cli/Program.elm
@@ -176,7 +176,7 @@ type alias StatefulOptions msg model cliOptions flags =
     , printAndExitSuccess : String -> Cmd msg
     , init : FlagsIncludingArgv flags -> cliOptions -> ( model, Cmd msg )
     , update : cliOptions -> msg -> model -> ( model, Cmd msg )
-    , subscriptions : model -> Sub msg
+    , subscriptions : cliOptions -> model -> Sub msg
     , config : Config cliOptions
     }
 
@@ -206,8 +206,8 @@ stateful options =
         , subscriptions =
             \model ->
                 case model of
-                    UserModel actualModel _ ->
-                        options.subscriptions actualModel
+                    UserModel actualModel cliOptions ->
+                        options.subscriptions cliOptions actualModel
 
                     ShowSystemMessage ->
                         Sub.none

--- a/tests/Cli/UsageSpecTests.elm
+++ b/tests/Cli/UsageSpecTests.elm
@@ -87,7 +87,7 @@ all =
                 OptionsParser.build identity
                     |> OptionsParser.with
                         (Option.requiredKeywordArg "report"
-                            |> Option.oneOf 123
+                            |> Option.oneOf
                                 [ ( "json", 123 )
                                 , ( "junit", 123 )
                                 , ( "console", 123 )
@@ -101,7 +101,7 @@ all =
                 OptionsParser.build identity
                     |> OptionsParser.with
                         (Option.requiredPositionalArg "report"
-                            |> Option.oneOf 123
+                            |> Option.oneOf
                                 [ ( "json", 123 )
                                 , ( "junit", 123 )
                                 , ( "console", 123 )

--- a/tests/OptionsParserTests.elm
+++ b/tests/OptionsParserTests.elm
@@ -343,7 +343,7 @@ all =
                         (OptionsParser.build identity
                             |> OptionsParser.with
                                 (Option.requiredKeywordArg "report"
-                                    |> Option.oneOf Console
+                                    |> Option.oneOf
                                         [ ( "json", Json )
                                         ]
                                 )
@@ -356,7 +356,7 @@ all =
                         (OptionsParser.build identity
                             |> OptionsParser.with
                                 (Option.requiredKeywordArg "report"
-                                    |> Option.oneOf Console
+                                    |> Option.oneOf
                                         [ ( "json", Json )
                                         ]
                                 )


### PR DESCRIPTION
Use internal package to avoid having to expose some internal types in… the public API, and address elm-review errors in the process.

cc @miniBill