### PR TITLE
Run elm-review in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "postinstall": "elm-tooling install",
-    "test": "elm make && elm-test",
+    "test": "elm make && elm-test && elm-review",
     "build-examples": "cd examples && elm make src/ElmTest.elm src/Git.elm src/Graphqelm.elm src/Simple.elm src/Validation.elm src/Curl.elm src/Grep.elm --output ./elm.js"
   },
   "devDependencies": {

--- a/review/elm.json
+++ b/review/elm.json
@@ -9,12 +9,12 @@
             "elm/core": "1.0.5",
             "elm/json": "1.1.4",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.16.2",
+            "jfmengels/elm-review": "2.16.6",
             "jfmengels/elm-review-code-style": "1.2.0",
             "jfmengels/elm-review-common": "1.3.5",
             "jfmengels/elm-review-debug": "1.0.8",
             "jfmengels/elm-review-documentation": "2.0.4",
-            "jfmengels/elm-review-simplify": "2.1.13",
+            "jfmengels/elm-review-simplify": "2.1.15",
             "jfmengels/elm-review-unused": "1.2.6",
             "stil4m/elm-syntax": "7.3.9"
         },
@@ -26,7 +26,7 @@
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.5",
-            "elm-explorations/test": "2.2.0",
+            "elm-explorations/test": "2.2.1",
             "pzp1997/assoc-list": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
@@ -34,7 +34,7 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "2.2.0"
+            "elm-explorations/test": "2.2.1"
         },
         "indirect": {}
     }

--- a/src/Cli/OptionsParser/BuilderState.elm
+++ b/src/Cli/OptionsParser/BuilderState.elm
@@ -32,16 +32,16 @@ take a look at
 {-| A state where you can add any options (beginning, middle, or terminal)
 -}
 type AnyOptions
-    = AnyOptions
+    = AnyOptions Never
 
 
 {-| A state where you can add anything but beginning options (i.e. middle or terminal)
 -}
 type NoBeginningOptions
-    = NoBeginningOptions
+    = NoBeginningOptions Never
 
 
 {-| A state where you can no longer add any options
 -}
 type NoMoreOptions
-    = NoMoreOptions
+    = NoMoreOptions Never


### PR DESCRIPTION
This will remove false positives from elm-review's NoUnused.CustomTypeConstructors rule.